### PR TITLE
Better accessToken parsing

### DIFF
--- a/placedebot.user.js
+++ b/placedebot.user.js
@@ -260,9 +260,7 @@ async function getAccessToken() {
 	const url = usingOldReddit ? 'https://new.reddit.com/r/place/' : 'https://www.reddit.com/r/place/';
 	const response = await fetch(url);
 	const responseText = await response.text();
-
-	// TODO: ew
-	return responseText.split('\"accessToken\":\"')[1].split('"')[0];
+	return responseText.match(/"accessToken"\s*:\s*"([\w-]+)"/)[1];
 }
 
 async function getCurrentImageUrl() {


### PR DESCRIPTION
There doesn't seem to be a better way of getting the access token actually since when Reddit fetches it, it deletes the property ___r from the window object and then moves the data into its apparently inaccessible redux store.
This uses a proper regex to parse the accessToken instead of splitting the text into an array.

I've tested that this change works on my account.