### PR TITLE
inaktive Chrome Tabs Workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Der Bot für PlaceDE! Dieser Bot holt automatisch alle paar Minuten [Pläne](htt
 1. Installiere die Browsererweiterung [Tampermonkey](https://www.tampermonkey.net/) oder [Violentmonkey (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/violentmonkey/).
 2. Klicke auf diesen Link: [https://github.com/PlaceDE/Bot/raw/main/placedebot.user.js](https://github.com/PlaceDE/Bot/raw/main/placedebot.user.js). Wenn alles gut geht, bietet Tampermonkey an, ein Benutzerskript zu installieren. Klicke auf **Installieren**.
 3. Lade den **r/place** Tab neu. Wenn alles gut gegangen ist, sollte "Abfrage des Zugriffstokens..." oben rechts auf dem Bildschirm zu sehen sein. Der Bot ist nun aktiv und wird diese Benachrichtigungen oben rechts für laufende Informationen nutzen.
+4. In Chrome werden Browsertabs in den Ruhemodus versetzt, wenn sie nicht mehr sichtbar oder im Hintergrund / minimiert sind. Lösung: in der Adresszeile nach `chrome://discards/` gehen, und dort bei auto-discardable togglen das dort ein X ist für den Bot-Tab, dann bleibt der tab active.
 
 ## Schwachstellen des Bots
 


### PR DESCRIPTION
Anleitung für Workaround beim Problem dass Chrome Tabs im Hintergrund pausiert. Stichwort "window occlusion"
Lösung von Chirimu aus dem placeDE Discord